### PR TITLE
feat: add Streamlit UI for task input and graph visualisation

### DIFF
--- a/taskgraph/ui/streamlit_app.py
+++ b/taskgraph/ui/streamlit_app.py
@@ -1,0 +1,23 @@
+import streamlit as st
+from taskgraph.core import parse_input_data
+from taskgraph.ui.visualise import generate_task_graph
+
+
+st.set_page_config(page_title="TaskGraph", layout="wide")
+
+st.title("TaskGraph")
+
+user_input = st.text_area(
+    "Enter tasks (use -> for dependencies)", 
+    height=200, 
+    placeholder="Example:\nTask A -> Task B -> Task C\nTask D"
+)
+
+if st.button("Generate Graph") and user_input.strip():
+    tasks = parse_input_data(user_input)
+
+    st.subheader("Parsed Task Data")
+    st.json(tasks)
+
+    st.subheader("Graph View")
+    generate_task_graph(tasks)

--- a/taskgraph/ui/visualise.py
+++ b/taskgraph/ui/visualise.py
@@ -1,5 +1,6 @@
 import networkx as nx 
 import matplotlib.pyplot as plt
+import streamlit as st
 
 def generate_task_graph(tasks: list[dict]):
     """
@@ -19,6 +20,6 @@ def generate_task_graph(tasks: list[dict]):
 
     pos = nx.spring_layout(G)
 
-    nx.draw(G, pos, with_labels=True, arrows=True, node_size=1500, node_color='green', font_size=10)
-    plt.title("Task Dependency Graph")
-    plt.show()
+    fig, ax = plt.subplots()
+    nx.draw(G, pos, with_labels=True, arrows=True, node_size=1000, node_color='green', font_size=8, ax=ax)
+    st.pyplot(fig) 


### PR DESCRIPTION
### Overview
This PR introduces the initial Streamlit-based interface for TaskGraph.

### Features
- Text area for entering multiline task input (using `->` to define dependencies)
- Button to generate and visualise the task dependency graph
- Displays parsed task data as JSON
- Uses `networkx.DiGraph` for directional edge rendering

### Notes
- Parser expects minimal task format: `Task A -> Task B`,
- Graph uses matplotlib with `st.pyplot()` for compatibility with Streamlit
- Imports require running with `PYTHONPATH=. streamlit run taskgraph/ui/streamlit_app.py`
