### PR TITLE
feat: add task status parsing support for updated input data

### DIFF
--- a/taskgraph/core.py
+++ b/taskgraph/core.py
@@ -28,7 +28,7 @@ def parse_dependencies(line: str) -> List[Tuple[str, Optional[str]]]:
     return pairs
 
 
-def extract_status(task_str: str) -> Tuple[str, str]:
+def extract_status(task_str: str) -> Tuple[str, Optional[str]]:
     """
     Extracts task name and status. 
 

--- a/taskgraph/core.py
+++ b/taskgraph/core.py
@@ -28,6 +28,33 @@ def parse_dependencies(line: str) -> List[Tuple[str, Optional[str]]]:
     return pairs
 
 
+def extract_status(task_str: str) -> Tuple[str, str]:
+    """
+    Extracts task name and status. 
+
+    Supported status tags: 
+        [todo], [inProgress], [done]
+    
+    Defaults to None if there is no status.
+
+    Args:
+        task_str (str): Task name and possibly status tag.
+
+    Returns:
+        Tuple[str, str]: (Task name, Status)
+    """
+    task_str = task_str.strip()
+
+    if task_str.endswith("[todo]"):
+        return task_str[:-6].strip(), "todo"
+    elif task_str.endswith("[inProgress]"):
+        return task_str[:-10].strip(), "inProgress"
+    elif task_str.endswith("[done]"):
+        return task_str[:-6].strip(), "done"
+    else: 
+        return task_str, None
+
+
 def parse_input_data(text: str) -> list[dict]:
     """
     Parses multiline text into a list of task dependencies.

--- a/taskgraph/core.py
+++ b/taskgraph/core.py
@@ -1,14 +1,18 @@
-def parse_dependencies(line: str):
+from typing import List, Tuple, Optional
+
+def parse_dependencies(line: str) -> List[Tuple[str, Optional[str]]]:
     """
     Parse a task dependency chain from a single line of input.
     Splits by '->' to extract parent, child pairs.
     Single task return (parent, None) tuples.
 
     Args:
-        line (str): ` _description_
+        line (str): Represents chain of tasks, using '->' to 
+            separate tasks.
 
     Returns:
-        _type_: _description_
+        List[Tuple[str, Optional[str]]]: A list of (parent, child) pairs.
+        If a task has no dependency, its child will be None.
     """
     tokens = [t.strip() for t in line.split("->")]
 

--- a/taskgraph/data/sample_input.txt
+++ b/taskgraph/data/sample_input.txt
@@ -1,3 +1,3 @@
-Task A -> Task B -> Task C
-Task D
+Task A [done] -> Task B -> Task C [todo]
+Task D 
 Task E -> Task F


### PR DESCRIPTION
### Summary

This PR adds support for parsing task status from the raw text input. Tasks can now include a `[status]` marker that is extracted and stored as part of the task object.

---

### What's Added

- New function `extract_status(task_str: str) -> Tuple[str, Optional[str]]`  
  Extracts: `[todo]`,  `[inProgress]`, or  `[done]`, tags from task names.
  Defaults to `None` if no status is present.

- Updated `parse_input_data()` logic:
  - Uses `extract_status()` to detect status for each task
  - Ensures both parent and child tasks retain correct status
  - Builds task dictionaries with `task`, `depends_on`, and `status` fields

- Updated docstrings and type hints to reflect `Optional[str]` status handling

---

### Input data supported

```text
Task A [done] -> Task B [todo]
Task C
Task D [inProgress]
