### PR TITLE
feat: visualise start-middle-end nodes using unique shapes + improved chart generation

### DIFF
--- a/taskgraph/core.py
+++ b/taskgraph/core.py
@@ -120,7 +120,7 @@ def assign_node_roles(tasks: List[Dict]) -> Dict[str, str]:
 
     Roles: 
         - 'start': Task with no dependencies.
-        - 'end': Task with dependencies.
+        - 'end': No other task depends on this task.
         - 'middle': All other tasks.
 
     Args:

--- a/taskgraph/core.py
+++ b/taskgraph/core.py
@@ -1,6 +1,10 @@
 from typing import List, Tuple, Optional, Dict
 
 
+# ------------------------
+# Task parsing helpers
+# ------------------------
+
 def parse_dependencies(line: str) -> List[Tuple[str, Optional[str]]]:
     """
     Parse a task dependency chain from a single line of input.
@@ -106,3 +110,38 @@ def parse_input_data(text: str) -> list[Dict[str, object]]:
                     tasks[child]["depends_on"].append(parent)
 
     return list(tasks.values())
+
+# ------------------------
+# Task logic helpers
+# ------------------------
+def assign_node_roles(tasks: List[Dict]) -> Dict[str, str]:
+    """
+    Assigns roles to tasks based on their dependencies. 
+
+    Roles: 
+        - 'start': Task with no dependencies.
+        - 'middle': Task with dependencies.
+        - 'end': All other tasks.
+
+    Args:
+        tasks (List[Dict]): List of task dictionaries. 
+
+    Returns:
+        Dict[str, str]: Role-node mapping.
+    """
+    start_nodes = {task["task"] for task in tasks if not task["dpends_on"]}
+    all_tasks = {task["task"] for task in tasks}
+    all_deps = {dep for task in tasks for dep in task["depends_on"]} 
+    end_nodes = all_tasks - all_deps
+
+    roles = {}
+    for task in tasks: 
+        name = task["task"]
+        if name in start_nodes:
+            roles[name] = "start"
+        elif name in end_nodes:
+            roles[name] = "end"
+        else:
+            roles[name] = "middle"
+    
+    return roles

--- a/taskgraph/core.py
+++ b/taskgraph/core.py
@@ -129,7 +129,7 @@ def assign_node_roles(tasks: List[Dict]) -> Dict[str, str]:
     Returns:
         Dict[str, str]: Role-node mapping.
     """
-    start_nodes = {task["task"] for task in tasks if not task["dpends_on"]}
+    start_nodes = {task["task"] for task in tasks if not task["depends_on"]}
     all_tasks = {task["task"] for task in tasks}
     all_deps = {dep for task in tasks for dep in task["depends_on"]} 
     end_nodes = all_tasks - all_deps

--- a/taskgraph/core.py
+++ b/taskgraph/core.py
@@ -120,8 +120,8 @@ def assign_node_roles(tasks: List[Dict]) -> Dict[str, str]:
 
     Roles: 
         - 'start': Task with no dependencies.
-        - 'middle': Task with dependencies.
-        - 'end': All other tasks.
+        - 'end': Task with dependencies.
+        - 'middle': All other tasks.
 
     Args:
         tasks (List[Dict]): List of task dictionaries. 

--- a/taskgraph/ui/visualise.py
+++ b/taskgraph/ui/visualise.py
@@ -11,6 +11,12 @@ STATUS_COLORS = {
     None: "grey",
 }
 
+ROLE_SHPAES = {
+    "start": "s",
+    "end": "d",
+    "middle": "o"
+}
+
 
 
 def generate_task_graph(tasks: List[Dict]):

--- a/taskgraph/ui/visualise.py
+++ b/taskgraph/ui/visualise.py
@@ -1,7 +1,8 @@
 import networkx as nx
 import matplotlib.pyplot as plt
 from matplotlib.patches import Patch
-import streamlit as st
+from typing import List, Dict
+from taskgraph.core import assign_node_roles
 
 STATUS_COLORS = {
     "todo": "lightgrey",
@@ -11,16 +12,19 @@ STATUS_COLORS = {
 }
 
 
-def generate_task_graph(tasks: list[dict]):
+
+def generate_task_graph(tasks: List[Dict]):
     """
-    Generates a visual task dependency graph from a list of task dictionaries.
+    Generates a visual task dependency graph from a List of task Dictionaries.
 
     Args:
-        tasks (list[dict]): Each dictionary must contain 'task' and 'depends_on'.
+        tasks (List[Dict]): Each Dictionary must contain 'task' and 'depends_on'.
     """
     G = nx.DiGraph()
 
     node_colors = []
+
+    node_roles = assign_node_roles(tasks)
 
     task_names = {task["task"] for task in tasks}
 

--- a/taskgraph/ui/visualise.py
+++ b/taskgraph/ui/visualise.py
@@ -1,7 +1,10 @@
-import networkx as nx
+from typing import Dict, List
+
 import matplotlib.pyplot as plt
+import networkx as nx
+from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
-from typing import List, Dict
+
 from taskgraph.core import assign_node_roles
 
 STATUS_COLORS = {
@@ -11,12 +14,7 @@ STATUS_COLORS = {
     None: "grey",
 }
 
-ROLE_SHPAES = {
-    "start": "s",
-    "end": "d",
-    "middle": "o"
-}
-
+ROLE_SHAPES = {"start": "s", "end": "d", "middle": "o"}
 
 
 def generate_task_graph(tasks: List[Dict]):
@@ -27,45 +25,73 @@ def generate_task_graph(tasks: List[Dict]):
         tasks (List[Dict]): Each Dictionary must contain 'task' and 'depends_on'.
     """
     G = nx.DiGraph()
-
-    node_colors = []
-
     node_roles = assign_node_roles(tasks)
-
     task_names = {task["task"] for task in tasks}
 
+    # --- Add nodes and edges ---
     for task in tasks:
-        task_name = task["task"]
-        status = task["status"]
-
-        G.add_node(task_name)
-        node_colors.append(STATUS_COLORS.get(status, "grey"))
+        G.add_node(task["task"])
 
     for task in tasks:
         for dep in task["depends_on"]:
-            if dep in task_names and task["task"] in task_names:
+            if dep in task_names:
                 G.add_edge(dep, task["task"])
 
     pos = nx.spring_layout(G, k=0.5)
 
     fig, ax = plt.subplots(figsize=(8, 3))
 
-    legend_elements = [
-        Patch(color=color, label=status) for status, color in STATUS_COLORS.items()
+    # --- Draw nodes and edges based on roles --
+
+    for role, shape in ROLE_SHAPES.items():
+        role_nodes = [
+            task["task"] for task in tasks if node_roles[task["task"]] == role
+        ]
+        role_colors = [
+            STATUS_COLORS.get(task["status"], "grey")
+            for task in tasks
+            if node_roles[task["task"]] == role
+        ]
+
+        nx.draw_networkx_nodes(
+            G,
+            pos,
+            nodelist=role_nodes,
+            node_color=role_colors,
+            node_shape=shape,
+            node_size=400,
+            ax=ax,
+        )
+
+    nx.draw_networkx_edges(G, pos, ax=ax, arrows=True)
+    nx.draw_networkx_labels(G, pos, font_size=5, ax=ax)
+
+    # --- Legends ---
+    color_legend = [
+        Patch(color=color, label=status if status else "None")
+        for status, color in STATUS_COLORS.items()
+    ]
+
+    shape_legend = [
+        Line2D(
+            [0],
+            [0],
+            marker=shape,
+            color="w",
+            label=role.title(),
+            markerfacecolor="grey",
+            markersize=8,
+        )
+        for role, shape in ROLE_SHAPES.items()
     ]
 
     ax.legend(
-        handles=legend_elements, loc="lower left", fontsize="x-small", frameon=False
+        handles=color_legend + shape_legend,
+        loc="lower left",
+        fontsize="x-small",
+        frameon=False,
     )
 
-    nx.draw(
-        G,
-        pos,
-        with_labels=True,
-        arrows=True,
-        node_size=400,
-        node_color=node_colors,
-        font_size=5,
-        ax=ax,
-    )
+    ax.set_title("Task Dependency Graph")
+
     return fig


### PR DESCRIPTION
## Summary

This PR improves the task graph visualisation by adding role-based node styling to highlight key structural positions in the task network.

---

### What's Included

- Added `assign_node_roles()` helper to classify each task as:
  - `start` (no dependencies)
  - `end` (no other tasks depend on it)
  - `middle` (connected both directions)
- Updated `generate_task_graph()` to:
  - Draw nodes by role using unique node shapes:
    - Squares for `start`
    - Diamonds for `end`
    - Circles for `middle`
  - Maintain colour styling by task `status` (todo, inProgress, done)
  - Add a second legend for shape-role mapping

---

### Technical Notes

- Rendering is now split into role groups using `nx.draw_networkx_nodes()`
- Task roles are recalculated based on filtered input (works with Streamlit filters)
- Graph layout, labels, and edge drawing remain unchanged